### PR TITLE
feat: 랜덤질문 답변 조회

### DIFF
--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/application/service/RandomQuestionServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/application/service/RandomQuestionServiceImpl.java
@@ -1,8 +1,6 @@
 package com.myhandjava.momentours.randomquestion.command.application.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 //@Service
 @Slf4j

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/domain/aggregate/RandomReply.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/domain/aggregate/RandomReply.java
@@ -1,0 +1,37 @@
+package com.myhandjava.momentours.randomquestion.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Table(name = "tb_randomreply")
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class RandomReply {
+
+    @Id
+    @Column(name = "random_reply_no")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int randomreplyno;
+
+    @Column(name = "random_reply_content")
+    private String randomreplycontent;
+
+    @Column(name = "random_reply_user_no")
+    private int randomreplyuserno;
+
+    @Column(name = "random_reply_question_no")
+    private int randomreplyquestionno;
+
+    @Column(name = "random_reply_is_deleted")
+    private int randomreplyisdeleted;
+
+    @Column(name = "random_couple_no")
+    private int randomcoupleno;
+
+}

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/dto/RandomQuestionAndReplyDTO.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/dto/RandomQuestionAndReplyDTO.java
@@ -1,0 +1,15 @@
+package com.myhandjava.momentours.randomquestion.query.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class RandomQuestionAndReplyDTO {
+    private RandomQuestionDTO question;
+    private RandomReplyDTO userReply;
+    private RandomReplyDTO partnerReply;
+    private boolean canViewPartnerReply;
+}

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/dto/RandomReplyDTO.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/dto/RandomReplyDTO.java
@@ -1,0 +1,17 @@
+package com.myhandjava.momentours.randomquestion.query.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class RandomReplyDTO {
+    private int randomReplyNo;
+    private String randomReplyContent;
+    private int randomReplyUserNo;
+    private int randomReplyQuestionNo;
+    private int randomReplyIsDeleted;
+    private int randomCoupleNo;
+}

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/repository/RandomReplyMapper.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/repository/RandomReplyMapper.java
@@ -1,0 +1,11 @@
+package com.myhandjava.momentours.randomquestion.query.repository;
+
+import com.myhandjava.momentours.randomquestion.command.domain.aggregate.RandomReply;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Map;
+
+@Mapper
+public interface RandomReplyMapper {
+    RandomReply findRandomReplyByQuestionNoAndUserNo(Map<String, Object> map);
+}

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionService.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionService.java
@@ -1,6 +1,9 @@
 package com.myhandjava.momentours.randomquestion.query.service;
 
+import com.myhandjava.momentours.randomquestion.query.dto.RandomQuestionAndReplyDTO;
 import com.myhandjava.momentours.randomquestion.query.dto.RandomQuestionDTO;
+import com.myhandjava.momentours.randomquestion.query.dto.RandomReplyDTO;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 import java.util.Map;
@@ -14,4 +17,8 @@ public interface RandomQuestionService {
     RandomQuestionDTO findRandomQuestionByDate(Map<String, Object> map);
 
     List<RandomQuestionDTO> findRandomQuestionByKeyword(Map<String, Object> map);
+
+    RandomReplyDTO findRandomReplyByQuestionNoAndUserNo(Map<String, Object> map);
+
+    RandomQuestionAndReplyDTO findCurrentRandomQuestionWithReplies(int userNo);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionServiceImpl.java
@@ -1,12 +1,17 @@
 package com.myhandjava.momentours.randomquestion.query.service;
 
 import com.myhandjava.momentours.randomquestion.command.domain.aggregate.RandomQuestion;
+import com.myhandjava.momentours.randomquestion.command.domain.aggregate.RandomReply;
+import com.myhandjava.momentours.randomquestion.query.dto.RandomQuestionAndReplyDTO;
 import com.myhandjava.momentours.randomquestion.query.dto.RandomQuestionDTO;
+import com.myhandjava.momentours.randomquestion.query.dto.RandomReplyDTO;
 import com.myhandjava.momentours.randomquestion.query.repository.RandomQuestionMapper;
+import com.myhandjava.momentours.randomquestion.query.repository.RandomReplyMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,15 +21,21 @@ import java.util.stream.Collectors;
 public class RandomQuestionServiceImpl implements RandomQuestionService {
 
     private final RandomQuestionMapper randomQuestionMapper;
+    private final RandomReplyMapper randomReplyMapper;
+//    private final CoupleService coupleService;
 
     @Autowired
-    public RandomQuestionServiceImpl(RandomQuestionMapper randomQuestionMapper) {
+    public RandomQuestionServiceImpl(RandomQuestionMapper randomQuestionMapper, RandomReplyMapper randomReplyMapper) {
         this.randomQuestionMapper = randomQuestionMapper;
+        this.randomReplyMapper = randomReplyMapper;
     }
 
+    // 최신 질문을 조회하기 위해선 회원 테이블 -> 커플 테이블 -> 질문 중 최신 1개의 과정이 요구된다
+    // 커플의 번호를 알기 위해선 Mapper.xml에서 쿼리에서 join을 통해 얻어내는 건지, 아니면 coupleService를 호출해서 얻어내는 건지 선생님께 물어볼 것
     @Override
     public RandomQuestionDTO findCurrentRandomQuestionByMemberNo(int userNo) {
-        RandomQuestion randomQuestion = randomQuestionMapper.findCurrentRandomQuestionByMemberNo(userNo);
+//        int coupleNo = coupleService.getCoupleByUserNo(userNo);
+        RandomQuestion randomQuestion = randomQuestionMapper.findCurrentRandomQuestionByMemberNo(userNo);  // coupleNo가 들어가야 맞지만 오류가 생기지 않도록 userNo 넣어놓음
         RandomQuestionDTO randomQuestionDTO = new RandomQuestionDTO(
                 randomQuestion.getRandquesno(), randomQuestion.getRandquescreatedate(), randomQuestion.getRandquescontent(),
                 randomQuestion.getRandquesreply(), randomQuestion.getRandquesisdeleted(), randomQuestion.getRandquescoupleno()
@@ -35,7 +46,8 @@ public class RandomQuestionServiceImpl implements RandomQuestionService {
 
     @Override
     public List<RandomQuestionDTO> findAllRandomQuestionByMemberNo(int userNo) {
-        List<RandomQuestion> randomQuestions = randomQuestionMapper.findAllRandomQuestionByMemberNo(userNo);
+//        int coupleNo = coupleService.getCoupleByUserNo(userNo);
+        List<RandomQuestion> randomQuestions = randomQuestionMapper.findAllRandomQuestionByMemberNo(userNo);  // userNo -> coupleNo로 바뀔 예정
 
         List<RandomQuestionDTO> randomQuestionDTOList = randomQuestions.stream().map(randomQuestion ->
                 new RandomQuestionDTO(randomQuestion.getRandquesno(), randomQuestion.getRandquescreatedate(),
@@ -71,5 +83,73 @@ public class RandomQuestionServiceImpl implements RandomQuestionService {
 
         log.info("반환된 값: {}", randomQuestionDTOList);
         return randomQuestionDTOList;
+    }
+
+    @Override
+    public RandomQuestionAndReplyDTO findCurrentRandomQuestionWithReplies(int userNo) {
+
+        // 회원 번호로 커플 객체 조회
+//        Couple couple = coupleService.getCoupleByUserNo(userNo);
+        // 커플 객체로 파트너 회원 번호 추출
+//        int partnerNo = (couple.getUserNo1() == userNo) ? couple.getUserNo2() : couple.getUserNo1();
+
+        RandomQuestion randomQuestion = randomQuestionMapper.findCurrentRandomQuestionByMemberNo(userNo);
+        RandomQuestionDTO randomQuestionDTO = new RandomQuestionDTO(randomQuestion.getRandquesno(), randomQuestion.getRandquescreatedate(),
+                                                    randomQuestion.getRandquescontent(), randomQuestion.getRandquesreply(),
+                                                    randomQuestion.getRandquesisdeleted(), randomQuestion.getRandquescoupleno()
+        );
+
+        Map<String, Object> usermap = new HashMap<>();
+        usermap.put("userNo", userNo);
+        usermap.put("randomQuestionNo", randomQuestion.getRandquesno());
+
+        Map<String, Object> partnermap = new HashMap<>();
+        partnermap.put("userNo", userNo);  // userNo -> partnerNo로 바뀔 예정
+        partnermap.put("randomQuestionNo", randomQuestion.getRandquesno());
+
+        RandomReplyDTO userReplyDTO = findRandomReplyByQuestionNoAndUserNo(usermap);
+        RandomReplyDTO partnerReplyDTO = findRandomReplyByQuestionNoAndUserNo(partnermap);
+        boolean canViewPartnerReply = userReplyDTO.getRandomReplyContent() != "텅";
+
+        RandomQuestionAndReplyDTO result = new RandomQuestionAndReplyDTO(
+          randomQuestionDTO,
+          userReplyDTO,
+          canViewPartnerReply ? partnerReplyDTO : createHiddenReplyDTO(),
+                canViewPartnerReply
+        );
+        log.info("질문과 답변 2개가 반환되는지 확인: {}", result);
+        return result;
+    }
+
+    @Override
+    public RandomReplyDTO findRandomReplyByQuestionNoAndUserNo(Map<String, Object> map) {
+
+        RandomReply randomReply;
+        RandomReplyDTO randomReplyDTO;
+        try {
+            randomReply = randomReplyMapper.findRandomReplyByQuestionNoAndUserNo(map);
+            if(randomReply != null) {
+                randomReplyDTO = new RandomReplyDTO(
+                        randomReply.getRandomreplyno(), randomReply.getRandomreplycontent(), randomReply.getRandomreplyuserno(),
+                        randomReply.getRandomreplyquestionno(), randomReply.getRandomreplyisdeleted(), randomReply.getRandomcoupleno()
+                );
+            } else {
+                randomReplyDTO = createEmptyReplyDTO();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        log.info("회원번호와 질문 번호로 질문에 대합 답변 조회결과: {}", randomReplyDTO);
+        return randomReplyDTO;
+    }
+    private RandomReplyDTO createHiddenReplyDTO() {
+        return new RandomReplyDTO(0, "조회를 위해선 답변을 작성해주세요",
+                0, 0, 0, 0);
+    }
+
+    private RandomReplyDTO createEmptyReplyDTO() {
+        return new RandomReplyDTO(0, "텅", 0,
+                0, 0, 0);
     }
 }

--- a/momentours/src/main/resources/mappers/randomquestion/RandomQuestionMapper.xml
+++ b/momentours/src/main/resources/mappers/randomquestion/RandomQuestionMapper.xml
@@ -13,16 +13,22 @@
         <result property="randquescoupleno" column="rand_ques_couple_no"/>
     </resultMap>
     <select id="findCurrentRandomQuestionByMemberNo" resultMap="RandomQuestionResultMap">
-        SELECT rq.rand_ques_no, rq.rand_ques_content, rq.rand_ques_createDate,
-               rq.rand_ques_reply, rq.rand_ques_couple_no, rq.rand_ques_is_deleted
-        FROM tb_randomquestion rq
-                 JOIN tb_couple cl
-                      ON (rq.rand_ques_couple_no = cl.couple_no)
-                          AND (cl.couple_user_no1 = #{userNo} OR cl.couple_user_no2 = #{userNo})
-                 JOIN tb_user u
-                      ON u.user_no = #{userNo}
-        ORDER BY rq.rand_ques_createDate DESC
-            LIMIT 1
+        SELECT
+            rq.rand_ques_no,
+            rq.rand_ques_content,
+            rq.rand_ques_createDate,
+            rq.rand_ques_reply,
+            rq.rand_ques_couple_no,
+            rq.rand_ques_is_deleted
+        FROM
+            tb_randomquestion rq
+                JOIN
+            tb_couple cl ON rq.rand_ques_couple_no = cl.couple_no
+        WHERE
+            cl.couple_no = #{coupleNo}
+        ORDER BY
+            rq.rand_ques_createDate DESC
+            LIMIT 1;
     </select>
 
     <select id="findAllRandomQuestionByMemberNo" resultMap="RandomQuestionResultMap">
@@ -51,12 +57,15 @@
     </select>
 
     <select id="findRandomQuestionByKeyword" resultMap="RandomQuestionResultMap" parameterType="map">
-        SELECT rq.rand_ques_no, rq.rand_ques_content, rq.rand_ques_createDate,
-               rq.rand_ques_reply, rq.rand_ques_couple_no, rq.rand_ques_is_deleted
+        SELECT rq.rand_ques_no,
+               rq.rand_ques_content,
+               rq.rand_ques_createDate,
+               rq.rand_ques_reply,
+               rq.rand_ques_couple_no,
+               rq.rand_ques_is_deleted
         FROM tb_randomquestion rq
-                 JOIN tb_couple cl ON rq.rand_ques_couple_no = cl.couple_no
-            AND (cl.couple_user_no1 = #{userNo} OR cl.couple_user_no2 = #{userNo})
-        WHERE rq.rand_ques_content LIKE CONCAT('%', #{keyword}, '%')
+        WHERE rq.rand_ques_couple_no = #{coupleNo}
+          AND rq.rand_ques_content LIKE CONCAT('%',#{keyword},'%')
         ORDER BY rq.rand_ques_createDate DESC;
     </select>
 </mapper>

--- a/momentours/src/main/resources/mappers/randomquestion/RandomReplyMapper.xml
+++ b/momentours/src/main/resources/mappers/randomquestion/RandomReplyMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.myhandjava.momentours.randomquestion.query.repository.RandomReplyMapper">
+    <resultMap id="RandomReplyResultMap" type="com.myhandjava.momentours.randomquestion.command.domain.aggregate.RandomReply">
+        <id property="randomreplyno" column="random_reply_no"/>
+        <result property="randomreplycontent" column="random_reply_content"/>
+        <result property="randomreplyuserno" column="random_reply_user_no"/>
+        <result property="randomreplyquestionno" column="random_reply_question_no"/>
+        <result property="randomreplyisdeleted" column="random_reply_is_deleted"/>
+        <result property="randomcoupleno" column="random_couple_no"/>
+    </resultMap>
+        <!-- 랜덤 질문의 답변은 반드시 질문이 먼저 조회된 후에 질문과 같이 하나의 답변만 보여주는 쿼리만 있으면 된다 -->
+    <select id="findRandomReplyByQuestionNoAndUserNo" resultMap="RandomReplyResultMap" parameterType="map">
+        SELECT
+            random_reply_no,
+            random_reply_content,
+            random_reply_user_no,
+            random_reply_is_deleted,
+            random_couple_no,
+            random_question_no
+        FROM
+            tb_randomreply
+        WHERE
+            random_reply_user_no = #{userNo}
+          AND random_question_no = #{randomQuestionNo}
+    </select>
+</mapper>

--- a/momentours/src/test/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionServiceTests.java
+++ b/momentours/src/test/java/com/myhandjava/momentours/randomquestion/query/service/RandomQuestionServiceTests.java
@@ -2,6 +2,7 @@ package com.myhandjava.momentours.randomquestion.query.service;
 
 import com.myhandjava.momentours.config.MybatisConfiguration;
 import com.myhandjava.momentours.randomquestion.query.dto.RandomQuestionDTO;
+import com.myhandjava.momentours.randomquestion.query.dto.RandomReplyDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,11 +40,11 @@ class RandomQuestionServiceTests {
         assertNotNull(randomQuestionDTOs);
     }
 
-    @DisplayName("날짜와 회원 번호로 랜덤질문 검색")
+    @DisplayName("날짜와 커플 번호로 랜덤질문 검색")
     @Test
     public void getRandomQuestionByMemberNoAndDate() {
         Map<String, Object> map = new HashMap<>();
-        map.put("userNo", 1);
+        map.put("coupleNo", 1);
         map.put("selectedDate", "2024-08-29");
         RandomQuestionDTO randomQuestionDTO =
                 randomQuestionService.findRandomQuestionByDate(map);
@@ -51,15 +52,31 @@ class RandomQuestionServiceTests {
         assertNotNull(randomQuestionDTO);
     }
 
-    @DisplayName("회원 번호와 키워드로 랜덤질문 검색")
+    @DisplayName("커플 번호와 키워드로 랜덤질문 검색")
     @Test
     public void getRandomQuestionByMemberNoAndKeyword() {
         Map<String, Object> map = new HashMap<>();
-        map.put("userNo", 1);
+        map.put("coupleNo", 1);
         map.put("keyword", "요?");
+
         List<RandomQuestionDTO> randomQuestionDTOs =
                 randomQuestionService.findRandomQuestionByKeyword(map);
 
         assertNotNull(randomQuestionDTOs);
+    }
+
+    @DisplayName("회원번호와 질문번호로 랜덤질문 답변 조회")
+    @Test
+    public void getRandomReply() {
+        int userNo = 1;
+        int randomQuestionNo = 1;
+        Map<String, Object> map = new HashMap<>();
+        map.put("userNo", userNo);
+        map.put("randomQuestionNo", randomQuestionNo);
+
+        RandomReplyDTO randomReplyDTO =
+                randomQuestionService.findRandomReplyByQuestionNoAndUserNo(map);
+
+        assertNotNull(randomReplyDTO);
     }
 }


### PR DESCRIPTION
---
name: 랜덤질문 답변 조회
about: 
회원 번호와 질문 번호로 랜덤질문을 조회하는 기능 개발, 
최신 랜덤질문을 조회할 때 내 답변과 파트너 답변 유무에 따른 객체 반환 기능 개발
랜덤질문을 조회시 회원서비스를 호출하여 커플 번호를 추출하도록 수정(만약 조인을 통해 얻어내는 거라면 다시 수정할 예정)
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- xml파일을 mybatis가 읽을 때 주석도 읽어서 임의의 쿼리를 노션에 임시로 옮겨 적어놨습니다.
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 
<img width="686" alt="image" src="https://github.com/user-attachments/assets/380812a9-55fd-4079-a0c6-71764722884f">


## 테스트 계획 또는 완료 사항
- [ ] 질문 답변을 회원 번호와 질문 번호로 조회하는 기능 테스트
- [ ] 회원 번호로 질문 조회, 답변 조회, 파트너 회원 답변 조회 후 3개를 dto로 만들어서 리턴하는 기능을 테스트할 예정
