### PR TITLE
refactor: 일기 삭제 기능 구조 개선

### DIFF
--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/controller/DiaryController.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/controller/DiaryController.java
@@ -55,7 +55,7 @@ public class DiaryController {
     }
 
     // 일기 삭제(soft delete)
-    @PutMapping("/{diaryNo}")
+    @DeleteMapping("/{diaryNo}")
     public ResponseEntity<?> removeDiary(@PathVariable int diaryNo, @RequestParam int userNo) {
 
         diaryService.removeDiary(diaryNo, userNo);

--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/service/DiaryServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/service/DiaryServiceImpl.java
@@ -11,6 +11,8 @@ import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -56,15 +58,10 @@ public class DiaryServiceImpl implements DiaryService {
         Diary diary = diaryRepository.findByDiaryNoAndDiaryUserNo(diaryNo, userNo)
                 .orElseThrow(() -> new EntityNotFoundException("해당 일기가 존재하지 않습니다."));;
 
-        if (diary != null) {
-            DiaryDTO diaryDTO = new DiaryDTO();
-            diaryDTO.setDiaryIsDeleted(1);
+        diary.setDiaryIsDeleted(true);
 
-            Diary diary1 = modelMapper.map(diaryDTO, Diary.class);
-            diaryRepository.save(diary1);
-        } else {
-            throw new EntityNotFoundException("해당 일기가 존재하지 않습니다.");
-        }
+        fileService.updateFileDiaryIsDeleted(diary);
+        diaryRepository.save(diary);
 
     }
 

--- a/momentours/src/main/java/com/myhandjava/momentours/file/command/application/service/FileService.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/command/application/service/FileService.java
@@ -9,4 +9,6 @@ import java.util.List;
 
 public interface FileService {
     List<FileEntity> saveFileDiary(List<MultipartFile> files, Diary diary) throws IOException;
+
+    void updateFileDiaryIsDeleted(Diary diary);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/file/command/application/service/FileServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/command/application/service/FileServiceImpl.java
@@ -4,9 +4,16 @@ import com.myhandjava.momentours.diary.command.domain.aggregate.Diary;
 import com.myhandjava.momentours.file.command.domain.aggregate.FileBoardSort;
 import com.myhandjava.momentours.file.command.domain.aggregate.FileEntity;
 import com.myhandjava.momentours.file.command.domain.repository.FileRepository;
+import com.myhandjava.momentours.file.query.dto.FileDTO;
+import com.myhandjava.momentours.file.query.repository.FileMapper;
+import jakarta.persistence.EntityNotFoundException;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -15,19 +22,29 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class FileServiceImpl implements FileService {
 
     private final FileRepository fileRepository;
+    private final FileMapper fileMapper;
     private final ResourceLoader resourceLoader;
+    private final ModelMapper modelMapper;
 
     @Autowired
-    public FileServiceImpl(FileRepository fileRepository, ResourceLoader resourceLoader) {
+    public FileServiceImpl(FileRepository fileRepository,
+                           FileMapper fileMapper,
+                           ResourceLoader resourceLoader,
+                           ModelMapper modelMapper) {
         this.fileRepository = fileRepository;
+        this.fileMapper = fileMapper;
         this.resourceLoader = resourceLoader;
+        this.modelMapper = modelMapper;
     }
 
+    @Override
+    @Transactional
     public List<FileEntity> saveFileDiary(List<MultipartFile> files, Diary diary) throws IOException {
         if(files.isEmpty()) {
             throw new IOException("업로드된 파일이 없습니다.");
@@ -51,7 +68,7 @@ public class FileServiceImpl implements FileService {
             diaryFile.setFileSaveName(saveName);
             diaryFile.setFileExtension(extension);
             diaryFile.setFileDirectory(filePath);
-            diaryFile.setFileBoardSort(FileBoardSort.DIARY);
+            diaryFile.setFileBoardSort(FileBoardSort.diary);
             diaryFile.setFileSize(BigDecimal.valueOf(files.get(i).getSize() / 1024.0));
             diaryFile.setDiary(diary);
 
@@ -59,5 +76,27 @@ public class FileServiceImpl implements FileService {
             savedFiles.add(fileRepository.save(diaryFile));
         }
         return savedFiles;
+    }
+
+    // 일기번호에 해당하는 파일 IsDeleted = true
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    public void updateFileDiaryIsDeleted(Diary diary) {
+
+        List<FileDTO> fileDTOList = fileMapper.selectFilesByDiaryNo(diary.getDiaryNo());
+
+        List<FileEntity> fileList = fileDTOList.stream()
+                .map(fileDTO -> modelMapper.map(fileDTO, FileEntity.class))
+                .collect(Collectors.toList());
+
+        if (fileList.isEmpty()) {
+            throw new EntityNotFoundException("해당 일기와 연관된 파일이 존재하지 않습니다.");
+        }
+
+        for (FileEntity file : fileList) {
+            file.setFileIsDeleted(true);
+        }
+
+        fileRepository.saveAll(fileList);
     }
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/aggregate/FileBoardSort.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/aggregate/FileBoardSort.java
@@ -2,28 +2,11 @@ package com.myhandjava.momentours.file.command.domain.aggregate;
 
 import lombok.Getter;
 
+@Getter
 public enum FileBoardSort {
-    MOMENT("moment"),
-    INQUIRY("inquiry"),
-    DIARY("diary");
-
-    private final String value;
-
-    FileBoardSort(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public static FileBoardSort fromValue(String value) {
-        for (FileBoardSort sort : FileBoardSort.values()) {
-            if (sort.getValue().equalsIgnoreCase(value)) {
-                return sort;
-            }
-        }
-        throw new IllegalArgumentException("정의 되지 않은 값: " + value);
-    }
+    moment,
+    inquiry,
+    diary
 }
+
 

--- a/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/aggregate/FileEntity.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/aggregate/FileEntity.java
@@ -41,16 +41,21 @@ public class FileEntity {
     @Column(name = "file_board_sort", nullable = false)
     private FileBoardSort fileBoardSort;
 
-    @Column(nullable = true)
-    private int inquiryNo;
-
-    @Column(nullable = true)
-    private int momentNo;
-
-    @Column(nullable = true)
-    private int coupleNo;
+    // 엔티티가 없어서...
+//    @ManyToOne
+//    @JoinColumn(name = "inquiry_no", nullable = true)
+//    private Inquiry inquiryNo;
+//
+//    @ManyToOne
+//    @JoinColumn(name = "moment_no", nullable = true)
+//    private Moment momentNo;
+//
+//    @ManyToOne
+//    @JoinColumn(name = "couple_no", nullable = true)
+//    private Couple coupleNo;
 
     @ManyToOne
     @JoinColumn(name = "diary_no", nullable = true)
     private Diary diary;
+
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/repository/FileRepository.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/command/domain/repository/FileRepository.java
@@ -2,8 +2,13 @@ package com.myhandjava.momentours.file.command.domain.repository;
 
 import com.myhandjava.momentours.diary.command.domain.aggregate.Diary;
 import com.myhandjava.momentours.file.command.domain.aggregate.FileEntity;
+import com.myhandjava.momentours.file.query.dto.FileDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface FileRepository extends JpaRepository<FileEntity, Integer> {
     void deleteByDiary(Diary diary);
+
+    List<FileEntity> findByDiary(Diary diary);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/file/query/dto/FileDTO.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/query/dto/FileDTO.java
@@ -1,6 +1,7 @@
 package com.myhandjava.momentours.file.query.dto;
 
 import com.myhandjava.momentours.diary.command.domain.aggregate.Diary;
+import com.myhandjava.momentours.file.command.domain.aggregate.FileBoardSort;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -19,6 +20,7 @@ public class FileDTO {
     private String fileExtension;
     private String fileDirectory;
     private boolean fileIsDeleted;
+    private FileBoardSort fileBoardSort;
     private int inquiryNo;
     private int momentNo;
     private int coupleNo;

--- a/momentours/src/main/java/com/myhandjava/momentours/file/query/repository/FileMapper.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/file/query/repository/FileMapper.java
@@ -1,7 +1,9 @@
 package com.myhandjava.momentours.file.query.repository;
 
 import com.myhandjava.momentours.file.query.dto.FileDTO;
+import jakarta.persistence.LockModeType;
 import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.List;
 

--- a/momentours/src/main/resources/mappers/diary/DiaryMapper.xml
+++ b/momentours/src/main/resources/mappers/diary/DiaryMapper.xml
@@ -25,6 +25,7 @@
           FROM tb_diary
          WHERE couple_no = #{ coupleNo }
            AND DATE(diary_create_date) = #{diaryCreateDate}
+           AND diary_is_deleted = false
     </select>
 
 </mapper>

--- a/momentours/src/main/resources/mappers/file/FileMapper.xml
+++ b/momentours/src/main/resources/mappers/file/FileMapper.xml
@@ -12,7 +12,7 @@
         <result property="fileExtension" column="file_extension"/>
         <result property="fileDirectory" column="file_directory"/>
         <result property="fileIsDeleted" column="file_is_deleted"/>
-<!--        <result property="fileBoardSort" column="file_board_sort"/>-->
+        <result property="fileBoardSort" column="file_board_sort" typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
         <result property="inquiryNo" column="inquiry_no"/>
         <result property="momentNo" column="moment_no"/>
         <result property="coupleNo" column="couple_no"/>
@@ -28,9 +28,11 @@
              , file_extension
              , file_directory
              , file_is_deleted
+             , file_board_sort
              , diary_no
           FROM tb_file
          WHERE diary_no = #{ diaryNo }
+           AND file_is_deleted = false
     </select>
 
 </mapper>

--- a/momentours/src/test/java/com/myhandjava/momentours/diary/command/application/service/DiaryServiceImplTests.java
+++ b/momentours/src/test/java/com/myhandjava/momentours/diary/command/application/service/DiaryServiceImplTests.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,7 +57,7 @@ class DiaryServiceImplTests {
         initialFile.setFileExtension(".jpg");
         initialFile.setFileDirectory("/uploads/");
         initialFile.setFileIsDeleted(false);
-        initialFile.setFileBoardSort(FileBoardSort.DIARY);
+        initialFile.setFileBoardSort(FileBoardSort.diary);
         initialFile.setDiary(diary);
         fileRepository.save(initialFile);
 
@@ -73,9 +74,15 @@ class DiaryServiceImplTests {
     @Transactional
     void removeDiary() {
 
-        Assertions.assertDoesNotThrow(
-                () -> diaryService.removeDiary(7, 2)
-        );
+        Assertions.assertDoesNotThrow(() -> diaryService.removeDiary(12, 2));
+
+        Diary deletedDiary = diaryRepository.findById(12)
+                .orElseThrow(() -> new AssertionError("일기 찾을 수 없습니다."));
+
+        List<FileEntity> deletedFiles = fileRepository.findByDiary(deletedDiary);
+        for (FileEntity file : deletedFiles) {
+            Assertions.assertTrue(file.isFileIsDeleted(), "isFileIsDeleted의 값이 true가 아님");
+        }
     }
 
     @Test
@@ -99,7 +106,7 @@ class DiaryServiceImplTests {
         initialFile.setFileExtension(".jpg");
         initialFile.setFileDirectory("/uploads/");
         initialFile.setFileIsDeleted(false);
-        initialFile.setFileBoardSort(FileBoardSort.DIARY);
+        initialFile.setFileBoardSort(FileBoardSort.diary);
         initialFile.setDiary(diary);
         fileRepository.save(initialFile);
 


### PR DESCRIPTION
---
name: 일기 삭제 기능 구조 개선
about: 일기 삭제 시 일기 isdeleted와 파일의 isdeleted 속성을 true로 해서 soft delete 되도록
title: ' #42 '
labels: Backend, refactor
assignees: 'yuhyejin'

---

## 무슨 이유로 코드를 변경했는가
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 1번째 에러 코드: org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [com.myhandjava.momentours.file.command.domain.aggregate.FileEntity#32]
🌈 해결 방법 : @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE) 동시성 문제로 @Transactional에 해당 속성 추가!
- 2번째 에러 코드: org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [com.myhandjava.momentours.file.command.domain.aggregate.FileEntity#32]
🌈 해결 방법: enum 클래스 부분에 이상한 값을 넣고 있었음!

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 
![스크린샷 2024-09-02 141633](https://github.com/user-attachments/assets/b99ccc0b-f923-4ae3-b800-371ada0aeb53)

## 테스트 계획 또는 완료 사항
- [x] 일기 삭제 시 일기의 isDeleted 속성과 파일의 isDeleted 속성이 true 바뀌는지 테스트 완료
