### PR TITLE
refactor: 커플 도메인 수정

### DIFF
--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/controller/CoupleController.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/controller/CoupleController.java
@@ -3,10 +3,10 @@ package com.myhandjava.momentours.couple.command.application.controller;
 import com.myhandjava.momentours.client.UserClient;
 import com.myhandjava.momentours.common.ResponseMessage;
 import com.myhandjava.momentours.couple.command.application.dto.CoupleDTO;
-import com.myhandjava.momentours.couple.command.application.service.CoupleServiceImpl;
+import com.myhandjava.momentours.couple.command.application.dto.CoupleRegisterDTO;
+import com.myhandjava.momentours.couple.command.application.service.CoupleService;
 import com.myhandjava.momentours.couple.command.domain.vo.CoupleRegistVO;
 import com.myhandjava.momentours.couple.command.domain.vo.CoupleUpdateVO;
-import com.myhandjava.momentours.couple.command.domain.vo.RequestSignCoupleVO;
 import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -24,83 +24,55 @@ import java.util.Map;
 public class CoupleController {
 
     private final ModelMapper modelMapper;
-    private final CoupleServiceImpl coupleService;
+    private final CoupleService coupleService;
     private final UserClient userClient;
 
     @Autowired
-    public CoupleController(ModelMapper modelMapper, CoupleServiceImpl coupleService, UserClient userClient) {
+    public CoupleController(ModelMapper modelMapper, CoupleService coupleService, UserClient userClient) {
         this.modelMapper = modelMapper;
         this.coupleService = coupleService;
         this.userClient = userClient;
     }
 
-    @PutMapping("")
-    public ResponseEntity<?> registNewCouple(@RequestAttribute("claims") Claims claims) {
-        log.info("넘어오긴함");
-        int userNo1 = (Integer)claims.get("userNo");
-
-
-        // 여기서 유저 번호로 유저 서비스에서 유저 테이블에 있는 파트너 번호 속성 조회해야 함
-        ResponseEntity<ResponseMessage> response = userClient.findPartnerByUserNo(userNo1);
-        Map<String, Object> map = new HashMap<>();
-        Integer lastCoupleNo = coupleService.findLastCoupleNo();
-        map.put("coupleNo", lastCoupleNo);
-        return ResponseEntity.ok(
-                new ResponseMessage(
-                        200, "커플 번호 반환 성공", map
-                )
-        );
+    @PostMapping("")
+    public ResponseEntity<ResponseMessage> registNewCouple(@RequestBody CoupleRegisterDTO coupleRegisterDTO) {
+        int userNo1 = coupleRegisterDTO.getUserNo1();
+        int userNo2 = coupleRegisterDTO.getUserNo2();
+        int coupleNo = coupleService.registCouple(userNo1, userNo2);
+        Map<String, Object> result = new HashMap<>();
+        result.put("coupleNo", coupleNo);
+        return ResponseEntity.ok(new ResponseMessage(200, "커플 객체 생성 성공", result));
     }
 
     @PostMapping("/profile")
-    public ResponseEntity<?> fillCoupleInfo(@RequestAttribute("claims") Claims claims,
+    public ResponseEntity<ResponseMessage> fillCoupleInfo(@RequestAttribute("claims") Claims claims,
                                             @RequestBody CoupleRegistVO coupleInfo) {
-        int userNo1 = (Integer)claims.get("userNo");
-        ResponseEntity<ResponseMessage> response = userClient.findPartnerByUserNo(userNo1);
-        Map<String, Object> map = response.getBody().getResult();
-        int userNo2 = (Integer)map.get("partnerNo");
-
-        // 입력된 커플 정보를 DTO로 변환
+        int coupleNo = (Integer) claims.get("coupleNo");
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CoupleDTO coupleDTO = modelMapper.map(coupleInfo, CoupleDTO.class);
-
-        // 커플 정보를 저장
-        coupleService.inputCoupleInfo(userNo1, userNo2, coupleDTO);
-
+        coupleService.inputCoupleInfo(coupleNo, coupleDTO);
         Map<String, Object> result = new HashMap<>();
-        map.put("updatedCouple", coupleDTO);
-        return ResponseEntity.ok(
-                new ResponseMessage(
-                        200, "커플 등록이 성공적으로 되었습니다!", result
-                )
-        );
+        result.put("updatedCouple", coupleDTO);
+        return ResponseEntity.ok(new ResponseMessage(200, "커플 정보 입력 성공", result));
     }
 
 
-    @PatchMapping("")
+    @PutMapping("/profile")
     public ResponseEntity<ResponseMessage> updateCoupleInfo(@RequestBody CoupleUpdateVO updateInfo,
-                                                            @RequestAttribute("claims") Claims coupleNo) {
+                                                            @RequestAttribute("claims") Claims claims) {
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        int updateCoupleNo = Integer.parseInt(coupleNo.get("coupleNo", String.class));
-        updateInfo.setCoupleNo(updateCoupleNo);
+        int coupleNo = (Integer)claims.get("coupleNo");
         CoupleDTO updatedCouple = modelMapper.map(updateInfo, CoupleDTO.class);
-
-        coupleService.updateCouple(updateInfo.getCoupleNo(), updatedCouple);
-
+        coupleService.updateCouple(coupleNo, updatedCouple);
         Map<String, Object> map = new HashMap<>();
         map.put("updatedCouple", updatedCouple);
-        return ResponseEntity.ok(
-                new ResponseMessage(
-                        200, "커플 정보가 수정되었습니다.", map
-                ));
+        return ResponseEntity.ok(new ResponseMessage(200, "커플 정보가 수정되었습니다.", map));
     }
 
-    @DeleteMapping("/{coupleNo}")
-    public ResponseEntity<ResponseMessage> deleteCoupleInfo(@PathVariable int coupleNo) {
+    @DeleteMapping("")
+    public ResponseEntity<ResponseMessage> deleteCoupleInfo(@RequestAttribute("claims") Claims claims) {
+        int coupleNo = (Integer)claims.get("coupleNo");
         coupleService.deleteCouple(coupleNo);
-
         return ResponseEntity.noContent().build();
     }
 }
-

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/dto/CoupleRegisterDTO.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/dto/CoupleRegisterDTO.java
@@ -1,0 +1,13 @@
+package com.myhandjava.momentours.couple.command.application.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class CoupleRegisterDTO {
+    private int userNo1;
+    private int userNo2;
+}

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleService.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleService.java
@@ -3,8 +3,8 @@ package com.myhandjava.momentours.couple.command.application.service;
 import com.myhandjava.momentours.couple.command.application.dto.CoupleDTO;
 
 public interface CoupleService {
-    void inputCoupleInfo(int userNo1, int userNo2, CoupleDTO couple);
+    void inputCoupleInfo(int coupleNo, CoupleDTO couple);
     void updateCouple(int coupleNo, CoupleDTO couple);
     void deleteCouple(int coupleNo);
-    Integer findLastCoupleNo();
+    int registCouple(int userNo1, int userNo2);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImpl.java
@@ -40,16 +40,28 @@ public class CoupleServiceImpl implements CoupleService {
     }
 
     @Override
-    public void inputCoupleInfo(int userNo1, int userNo2, CoupleDTO couple) {
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-        Couple newCouple = modelMapper.map(couple, Couple.class);
+    @Transactional
+    public int registCouple(int userNo1, int userNo2) {
+        Couple newCouple = new Couple();
         newCouple.setCoupleUserNo1(userNo1);
         newCouple.setCoupleUserNo2(userNo2);
-
+        newCouple.setCoupleIsDeleted(0);
         log.info("입력된 커플 정보: {}", newCouple);
         coupleRepository.save(newCouple);
+        return newCouple.getCoupleNo();
     }
 
+    @Transactional
+    @Override
+    public void inputCoupleInfo(int coupleNo, CoupleDTO coupleInfo) {
+        Couple couple = coupleRepository.findByCoupleNo(coupleNo);
+        couple.setCoupleName(coupleInfo.getCoupleName());
+        couple.setCouplePhoto(coupleInfo.getCouplePhoto());
+        couple.setCoupleStartDate(coupleInfo.getCoupleStartDate());
+        coupleRepository.save(couple);
+    }
+
+    @Transactional
     @Override
     public void deleteCouple(int coupleNo) {
         Couple couple = coupleRepository.findByCoupleNo(coupleNo);
@@ -57,12 +69,5 @@ public class CoupleServiceImpl implements CoupleService {
 
         log.info("삭제된 커플 정보: {}", couple);
         coupleRepository.save(couple);
-    }
-
-    @Override
-    public Integer findLastCoupleNo() {
-        Integer lastCoupleNo = coupleRepository.findMaxCoupleNo();
-        log.info("마지막 커플 pk값: {}", lastCoupleNo);
-        return lastCoupleNo + 1;
     }
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/domain/vo/CoupleUpdateVO.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/domain/vo/CoupleUpdateVO.java
@@ -13,5 +13,4 @@ public class CoupleUpdateVO {
     private String coupleName;
     private String couplePhoto;
     private LocalDateTime coupleStartDate;
-    private int coupleNo;
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/query/controller/CoupleController.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/query/controller/CoupleController.java
@@ -2,6 +2,7 @@ package com.myhandjava.momentours.couple.query.controller;
 
 import com.myhandjava.momentours.common.ResponseMessage;
 import com.myhandjava.momentours.couple.query.dto.CoupleDTO;
+import com.myhandjava.momentours.couple.query.service.CoupleService;
 import com.myhandjava.momentours.couple.query.service.CoupleServiceImpl;
 import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,10 +16,10 @@ import java.util.Map;
 @RequestMapping("/couple")
 public class CoupleController {
 
-    private final CoupleServiceImpl coupleService;
+    private final CoupleService coupleService;
 
     @Autowired
-    public CoupleController(CoupleServiceImpl coupleService) {
+    public CoupleController(CoupleService coupleService) {
         this.coupleService = coupleService;
     }
 

--- a/momentours/src/main/java/com/myhandjava/momentours/couple/query/service/CoupleServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/query/service/CoupleServiceImpl.java
@@ -27,7 +27,6 @@ public class CoupleServiceImpl implements CoupleService {
     @Override
     public CoupleDTO findCoupleByCoupleNo(int coupleNo) {
         CoupleDTO coupleDTO = coupleMapper.findCoupleByCoupleNo(coupleNo);
-
         log.info("조회된 커플 정보: {}" , coupleDTO);
         return coupleDTO;
     }


### PR DESCRIPTION
---
name: 커플 도메인 수정
about: 컨트롤러의 핸들러 메소드를 다른 도메인과 통일, 회원 도메인에서 서로 이메일을 입력해 역할을 커플로 바꿀 때 임의의 커플 객체 생성
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 회원쪽에서 토큰을 사용해서 makecouple 메서드를 실행하고 싶었는데 자꾸 토큰이 없다고 나왔습니다.
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항
- [x] 커플 번호 반환
