### PR TITLE
feat: 커플 삭제 시 다이어리 관련 데이터 삭제 기능 추가

### DIFF
--- a/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImpl.java
@@ -3,10 +3,11 @@ package com.myhandjava.momentours.couple.command.application.service;
 import com.myhandjava.momentours.couple.command.application.dto.CoupleDTO;
 import com.myhandjava.momentours.couple.command.domain.aggregate.Couple;
 import com.myhandjava.momentours.couple.command.domain.repository.CoupleRepository;
+import com.myhandjava.momentours.diary.command.application.service.DiaryService;
+import com.myhandjava.momentours.moment.command.application.service.MomentService;
 import com.myhandjava.momentours.randomquestion.command.application.service.RandomQuestionAndReplyCommandService;
-import com.myhandjava.momentours.randomquestion.command.application.service.RandomQuestionAndReplyCommandServiceImpl;
+import com.myhandjava.momentours.schedule.command.application.service.ScheduleService;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +15,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class CoupleServiceImpl implements CoupleService {
 
-    private final ModelMapper modelMapper;
     private final CoupleRepository coupleRepository;
     private final RandomQuestionAndReplyCommandService randomQuesCommandService;
+    private final DiaryService diaryService;
+    private final MomentService momentService;
+    private final ScheduleService scheduleService;
 
-    public CoupleServiceImpl(ModelMapper modelMapper, CoupleRepository coupleRepository, RandomQuestionAndReplyCommandServiceImpl randomQuesCommandService) {
-        this.modelMapper = modelMapper;
+    public CoupleServiceImpl(CoupleRepository coupleRepository, MomentService momentService,
+                             RandomQuestionAndReplyCommandService randomQuesCommandService,
+                             DiaryService diaryService, ScheduleService scheduleService) {
         this.coupleRepository = coupleRepository;
         this.randomQuesCommandService = randomQuesCommandService;
+        this.diaryService = diaryService;
+        this.momentService = momentService;
+        this.scheduleService = scheduleService;
     }
 
     @Override
@@ -69,7 +76,12 @@ public class CoupleServiceImpl implements CoupleService {
     public void deleteCouple(int coupleNo) {
         Couple couple = coupleRepository.findByCoupleNo(coupleNo);
         couple.setCoupleIsDeleted(1);
+        // 랜덤질문 모두 삭제
         randomQuesCommandService.removeAllRandomQuestionAndReply(coupleNo);
+        diaryService.removeAllDiary(coupleNo);
+//        momentService.removeAllMoment(coupleNo);
+//        scheduleService.removeAllSchedule(coupleNo);
+
         log.info("삭제된 커플 정보: {}", couple);
         coupleRepository.save(couple);
     }

--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/service/DiaryService.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/application/service/DiaryService.java
@@ -20,4 +20,6 @@ public interface DiaryService {
     void modifyComment(int commentNo, CommentDTO commentDTO);
 
     void registTempDiary(DiaryDTO diaryDTO);
+
+    void removeAllDiary(int coupleNo);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/CommentRepository.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/CommentRepository.java
@@ -3,8 +3,10 @@ package com.myhandjava.momentours.diary.command.domain.repository;
 import com.myhandjava.momentours.diary.command.domain.aggregate.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
     Optional<Comment> findByCommentNoAndCommentUserNo(int commentNo, int commentUserNo);
+    Optional<List<Comment>> findAllByDiaryNo(int diaryNo);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/DiaryRepository.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/DiaryRepository.java
@@ -4,8 +4,10 @@ import com.myhandjava.momentours.diary.command.domain.aggregate.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Integer> {
     Optional<Diary> findByDiaryNoAndDiaryUserNo(int diaryNo, int userNo);
+    Optional<List<Diary>> findAllByCoupleNo(int coupleNo);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/TemporaryRepository.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/diary/command/domain/repository/TemporaryRepository.java
@@ -3,5 +3,9 @@ package com.myhandjava.momentours.diary.command.domain.repository;
 import com.myhandjava.momentours.diary.command.domain.aggregate.Temporary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface TemporaryRepository extends JpaRepository<Temporary, Integer> {
+    Optional<List<Temporary>> findAllByDiaryNo(int diaryNo);
 }

--- a/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/application/service/RandomQuestionAndReplyCommandServiceImpl.java
+++ b/momentours/src/main/java/com/myhandjava/momentours/randomquestion/command/application/service/RandomQuestionAndReplyCommandServiceImpl.java
@@ -148,12 +148,10 @@ public class RandomQuestionAndReplyCommandServiceImpl implements RandomQuestionA
         List<RandomQuestion> allQuestions = questionRepository.findAllByRandQuesCoupleNo(coupleNo);
         List<RandomReply> allReplies = replyRepository.findAllByRandomCoupleNo(coupleNo);
         for(RandomQuestion q : allQuestions) {
-            q.setRandQuesIsDeleted(1);
-            questionRepository.save(q);
+            questionRepository.delete(q);
         }
         for(RandomReply r : allReplies) {
-            r.setRandomReplyIsDeleted(1);
-            replyRepository.save(r);
+            replyRepository.delete(r);
         }
     }
 }

--- a/momentours/src/test/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImplTests.java
+++ b/momentours/src/test/java/com/myhandjava/momentours/couple/command/application/service/CoupleServiceImplTests.java
@@ -2,11 +2,14 @@ package com.myhandjava.momentours.couple.command.application.service;
 
 import com.myhandjava.momentours.couple.command.application.dto.CoupleDTO;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,30 +19,111 @@ class CoupleServiceImplTests {
     @Autowired
     private CoupleService coupleService;
 
+    private static Stream<Arguments> dataSource1() {
+        return Stream.of(
+                Arguments.of(1,new CoupleDTO(
+                        "시바견 커플",
+                        "시바.jpg",
+                        LocalDateTime.of(2023, 6, 15, 14, 30, 0),
+                        1,
+                        2,
+                        0
+                )),
+                Arguments.of(2,new CoupleDTO(
+                        "고양이 커플",
+                        "고양.jpg",
+                        LocalDateTime.of(2024, 1, 22, 9, 45, 30),
+                        3,
+                        4,
+                        0
+                )),
+                Arguments.of(3,new CoupleDTO(
+                        "개구리 커플",
+                        "개굴.jpg",
+                        LocalDateTime.of(2023, 12, 31, 23, 59, 59),
+                        5,
+                        6,
+                        0
+                )),
+                Arguments.of(4,new CoupleDTO(
+                        "오리 커플",
+                        "꽥.jpg",
+                        LocalDateTime.now(),
+                        7,
+                        8,
+                        0
+                ))
+        );
+    }
+
     @DisplayName("커플 생성할 때 정보 입력 테스트")
-    @Test
-    void inputCoupleInformation() {
-        int coupleNo = 1;
-        CoupleDTO coupleDTO = new CoupleDTO();
-        coupleDTO.setCouplePhoto("강아지.jpg");
-        coupleDTO.setCoupleName("강아지 커플");
-        coupleDTO.setCoupleStartDate(LocalDateTime.now());
+    @ParameterizedTest
+    @MethodSource("dataSource1")
+    void inputCoupleInformation(int coupleNo, CoupleDTO coupleDTO) {
 
         assertDoesNotThrow(() -> coupleService.inputCoupleInfo(coupleNo, coupleDTO));
     }
 
+    private static Stream<Arguments> dataSource2() {
+        return Stream.of(
+                Arguments.of(1,new CoupleDTO(
+                        "한국 커플",
+                        "서울.jpg",
+                        LocalDateTime.of(2022, 8, 15, 14, 30, 0),
+                        1,
+                        2,
+                        0
+                )),
+                Arguments.of(2,new CoupleDTO(
+                        "중국 커플",
+                        "상해.jpg",
+                        LocalDateTime.of(2020, 11, 2, 9, 45, 30),
+                        3,
+                        4,
+                        0
+                )),
+                Arguments.of(3,new CoupleDTO(
+                        "일본 커플",
+                        "동경.jpg",
+                        LocalDateTime.of(2021, 3, 31, 23, 59, 59),
+                        5,
+                        6,
+                        0
+                )),
+                Arguments.of(4,new CoupleDTO(
+                        "미국 커플",
+                        "워싱턴.jpg",
+                        LocalDateTime.now(),
+                        7,
+                        8,
+                        0
+                ))
+        );
+    }
+
     @DisplayName("커플 정보 수정 테스트")
-    @Test
-    void updateCoupleInformation() {
-        int coupleNO = 1;
-        CoupleDTO coupleDTO = new CoupleDTO();
-        coupleDTO.setCoupleUserNo2(1);
-        coupleDTO.setCoupleUserNo1(2);
-        coupleDTO.setCoupleIsDeleted(0);
-        coupleDTO.setCoupleName("고양이 커플");
-        coupleDTO.setCoupleStartDate(LocalDateTime.now());
-        coupleDTO.setCouplePhoto("고양이.jpg");
+    @ParameterizedTest
+    @MethodSource("dataSource2")
+    void updateCoupleInformation(int coupleNO, CoupleDTO coupleDTO) {
 
         assertDoesNotThrow(() -> coupleService.updateCouple(coupleNO, coupleDTO));
+    }
+
+    private static Stream<Arguments> dataSource3() {
+        return Stream.of(
+                Arguments.of(1),
+                Arguments.of(2),
+                Arguments.of(3),
+                Arguments.of(4)
+
+        );
+    }
+
+    @DisplayName("커플 삭제 테스트")
+    @ParameterizedTest
+    @MethodSource("dataSource3")
+    void deleteCoupleInfo(int coupleNo) {
+
+        assertDoesNotThrow(() -> coupleService.deleteCouple(coupleNo));
     }
 }


### PR DESCRIPTION
---
name: 커플 삭제 시 다이어리 관련 데이터 삭제 기능 추가
about: 커플 삭제 시 isdeleted = 1로 바꾸고 커플이 쓴 모든 일기와 그와 관련된 파일, 댓글을 지우는(hard delete) 기능을 개발 및 테스트했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- FileRepo에서 findByDiary가 있어서 사용했는데 왜 Optional 안 쓰고 바로 Entity로 받는지 알고 싶습니다.

## 관련 스크린 샷 
<img width="756" alt="image" src="https://github.com/user-attachments/assets/1ac2d624-d603-4251-b6d7-b3827ec3483e">
<img width="756" alt="image" src="https://github.com/user-attachments/assets/89c26b41-d865-4ed4-865c-dde51abdcb32">
<img width="756" alt="image" src="https://github.com/user-attachments/assets/ee6622f6-7ab9-44e2-8046-eddeb6d14cf4">

## 테스트 계획 또는 완료 사항
- [x] 커플 정보 입력 테스트
- [x] 커플 정보 수정 테스트
- [x] 커플 삭제 테스트